### PR TITLE
chore: github action version bumps

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       REPORT_GAS: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -17,7 +17,7 @@ jobs:
       REPORT_GAS: true
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 16
 


### PR DESCRIPTION
 ## What

Updating Github Action references in all workflows.

## Why

Github Actions node16 deprecation. See [blog post (github.blog)](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)
> Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). As a result we have started the deprecation process of Node16 for GitHub Actions. We plan to migrate all actions to run on Node20 by Spring 2024.
> Following on from our [warning in workflows using Node16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) we will start enforcing the use of Node20 rather than Node16 on the 13th of May.

## Notes

RE-2531


Outdated Dependency Paths:

```
[ERROR] Deprecated dependencies found (2)!!
contracts.yml -> test -> actions/checkout@v2 -> node12
contracts.yml -> test -> actions/setup-node@v2 -> node12
``` 